### PR TITLE
Update Metals version to 1.6.2 and improve configuration management

### DIFF
--- a/project.scala
+++ b/project.scala
@@ -1,5 +1,8 @@
 //> using scala "3.7.1"
 
+// Metals version configuration
+//> using resourceDir "src/main/resources"
+
 // JSON processing dependencies
 //> using dep "io.circe::circe-core:0.14.14"
 //> using dep "io.circe::circe-parser:0.14.14"

--- a/src/main/resources/metals.properties
+++ b/src/main/resources/metals.properties
@@ -1,0 +1,2 @@
+# Metals Language Server Configuration
+metals.version=1.6.2

--- a/src/main/scala/scala/meta/metals/standalone/MetalsConfig.scala
+++ b/src/main/scala/scala/meta/metals/standalone/MetalsConfig.scala
@@ -1,0 +1,32 @@
+package scala.meta.metals.standalone
+
+import java.util.Properties
+import scala.util.Try
+import java.util.logging.Logger
+
+/** Configuration for Metals language server versions and settings.
+  */
+object MetalsConfig:
+  private val logger = Logger.getLogger(MetalsConfig.getClass.getName)
+  
+  private lazy val properties: Properties = 
+    val props = new Properties()
+    Try {
+      val stream = getClass.getClassLoader.getResourceAsStream("metals.properties")
+      if stream != null then
+        props.load(stream)
+        stream.close()
+      else
+        logger.warning("metals.properties not found, using fallback values")
+    }.recover { case e =>
+      logger.warning(s"Failed to load metals.properties: ${e.getMessage}")
+    }
+    props
+  
+  /** The Metals version to use when fetching via Coursier */
+  lazy val metalsVersion: String = 
+    properties.getProperty("metals.version", "1.6.2")
+  
+  /** The full Metals artifact coordinates for Coursier */
+  lazy val metalsArtifact: String = 
+    s"org.scalameta:metals_2.13:$metalsVersion"

--- a/src/main/scala/scala/meta/metals/standalone/MetalsLauncher.scala
+++ b/src/main/scala/scala/meta/metals/standalone/MetalsLauncher.scala
@@ -38,7 +38,7 @@ class MetalsLauncher(projectPath: Path):
         logger.info("Attempting to fetch Metals classpath via Coursier...")
 
         // Use coursier fetch command to get classpath
-        val command        = Seq(cs, "fetch", "--classpath", "org.scalameta:metals_2.13:1.6.0")
+        val command        = Seq(cs, "fetch", "--classpath", MetalsConfig.metalsArtifact)
         val processBuilder = new java.lang.ProcessBuilder(command.asJava)
         val process        = processBuilder.start()
         val result         = scala.io.Source.fromInputStream(process.getInputStream).mkString.trim


### PR DESCRIPTION
- Upgrade Metals from 1.6.0 to 1.6.2 (Osmium release)
- Add MetalsConfig object for centralized version management
- Store Metals version in src/main/resources/metals.properties
- Refactor MetalsLauncher to use configurable version from MetalsConfig
- This makes future Metals version upgrades cleaner and more maintainable

🤖 Generated with [Claude Code](https://claude.ai/code)